### PR TITLE
Fix handling versions that do not conform to semver

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,7 +141,15 @@ func normalizeVersion(version string) string {
 		version = strings.Split(version, "+")[0]
 	}
 	if strings.Contains(version, "-") {
-		version = strings.Split(version, "-")[2]
+		parts := strings.Split(version, "-")
+		// If the version doesn't have three parts then it is a custom named
+		// version and we should just return it as is.
+		if len(parts) < 3 {
+			return version
+		}
+		// If the version has three parts the last part should be the commit
+		// hash and that is essentially the version.
+		version = parts[2]
 	}
 	return version
 }

--- a/testdata/1-cmp
+++ b/testdata/1-cmp
@@ -66,3 +66,4 @@
  65	gopkg.in/go-playground/assert.v1				+	v1.2.1		https://gopkg.in/go-playground/assert.v1					
  66	gopkg.in/go-playground/validator.v8				+	v8.18.2		https://gopkg.in/go-playground/validator.v8					
  67	gopkg.in/mgo.v2							+	9856a29383ce	https://gopkg.in/mgo.v2								
+ 68	honnef.co/go/tools				c2f93a96b099	>	v0.0.1-2020.1.3											

--- a/testdata/1-left
+++ b/testdata/1-left
@@ -810,3 +810,10 @@
 	"Dir": "/home/leighmcculloch/go/pkg/mod/gopkg.in/yaml.v2@v2.2.2",
 	"GoMod": "/home/leighmcculloch/go/pkg/mod/cache/download/gopkg.in/yaml.v2/@v/v2.2.2.mod"
 }
+{
+	"Path": "honnef.co/go/tools",
+	"Version": "v0.0.0-20190102054323-c2f93a96b099",
+	"Time": "2019-01-02T05:43:23Z",
+	"Indirect": true,
+	"GoMod": "/home/leighmcculloch/go/pkg/mod/cache/download/honnef.co/go/tools/@v/v0.0.0-20190102054323-c2f93a96b099.mod"
+}

--- a/testdata/1-right
+++ b/testdata/1-right
@@ -1101,3 +1101,10 @@
 	"Dir": "/home/leighmcculloch/go/pkg/mod/gopkg.in/yaml.v2@v2.2.2",
 	"GoMod": "/home/leighmcculloch/go/pkg/mod/cache/download/gopkg.in/yaml.v2/@v/v2.2.2.mod"
 }
+{
+	"Path": "honnef.co/go/tools",
+	"Version": "v0.0.1-2020.1.3",
+	"Time": "2020-02-22T11:51:38Z",
+	"GoMod": "/home/leighmcculloch/go/pkg/mod/cache/download/honnef.co/go/tools/@v/v0.0.1-2020.1.3.mod",
+	"GoVersion": "1.11"
+}


### PR DESCRIPTION
### What
When encountering a version that doesn't conform to the standard semver version format (vX.Y.Z) or the format that Go uses for tagless versions (v0.0.0-date-hash), fallback to just using the raw version name as the version.

### Why
While most developers use either semver tags for their versions, or no tags, some developers use non-standard formats for their tags and when we encounter these we should just use this as the version and not try to parse commit hashes out of them. The code is currently trying to parse a commit hash (the third component) out of `v0.0.1-2020.1.3` and raising an error because there is no third component.

This bug was discovered when using `golistcmp` on the `go list -m -json all` output for the dependencies in stellar/go#2430.
