### PR TITLE
Add GitHub Actions build to replace CircleCI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,8 @@
+name: Go
+on: [push, pull_request]
+jobs:
+  build:
+    name: Build
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2-beta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v2-beta

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # golistcmp
+
+[![Build Status](https://github.com/stellar/golistcmp/workflows/Go/badge.svg)](https://github.com/stellar/golistcmp/actions)
+
 A tool for comparing the output of `go list -m -json` executions.
 
 ## Install


### PR DESCRIPTION
### What
Add GitHub Actions build to replace CircleCI.

### Why
From time to time we have some painful error with CircleCI. Like just
now for some reason builds on this repository are failing. We were
experimenting with GitHub Actions on small projects, e.g. the
`stellar/go-xdr` project is using it. This is a small project, and it
was easier for me to copy of the GitHub Actions build file than it was
to debug CircleCI yet again. I'll dig into it if this doesn't work easy.

Requesting your review @tomquisel because you were always excited
about GitHub Actions.