### PR TITLE
remove circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,0 @@
-version: 2
-jobs:
-  build:
-    docker:
-    - image: circleci/golang:1.13
-
-    steps:
-    - checkout
-    - run: go test -cover ./...


### PR DESCRIPTION
### What
Remove Circle CI files.

### Why
We have GitHub Actions setup in this repo and we don't need both.